### PR TITLE
Upgrade to Spring Boot 4.0.6 (superpom 6.4.0 + helpers 7.1.0 + springdoc 3.0.3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.entur.ror</groupId>
         <artifactId>superpom</artifactId>
-        <version>5.6.0</version>
+        <version>6.4.0</version>
     </parent>
     <groupId>org.entur</groupId>
     <artifactId>mummu</artifactId>
@@ -14,7 +14,7 @@
     <description>Read-only API for stop place related NeTEx entities</description>
     <properties>
         <java.version>21</java.version>
-        <entur.helpers.version>5.50.0</entur.helpers.version>
+        <entur.helpers.version>7.1.0</entur.helpers.version>
         <netex-parser-java.version>3.1.78</netex-parser-java.version>
         <jakarta-xml-bind.version>4.0.5</jakarta-xml-bind.version>
         <glassfish-jaxb.version>4.0.7</glassfish-jaxb.version>
@@ -98,6 +98,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
         <dependency>
@@ -125,7 +130,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.16</version>
+            <version>3.0.3</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/no/entur/mummu/resources/RestErrorController.java
+++ b/src/main/java/no/entur/mummu/resources/RestErrorController.java
@@ -1,7 +1,7 @@
 package no.entur.mummu.resources;
 
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.boot.web.servlet.error.ErrorController;
+import org.springframework.boot.webmvc.error.ErrorController;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;

--- a/src/test/java/no/entur/mummu/RestResourceIntegrationTest.java
+++ b/src/test/java/no/entur/mummu/RestResourceIntegrationTest.java
@@ -13,7 +13,7 @@ import java.nio.file.Path;
 import org.rutebanken.netex.model.ScheduledStopPoint;
 import org.rutebanken.netex.model.StopPlace;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;


### PR DESCRIPTION
## Spring Boot 4.x upgrade

Moves the application from Spring Boot 3.5.14 to **4.0.6** (Spring Framework 7 / Spring Security 7 / Tomcat 11). These three dependency bumps are **coupled** — each fails to build on its own, which is why the corresponding Renovate PRs (#335, #319, #315) show red CI individually:

| Dependency | From | To | Note |
|---|---|---|---|
| `org.entur.ror:superpom` | 5.6.0 | 6.4.0 | The Boot 3.5.14 → 4.0.6 bump |
| `entur.helpers` (stopplace-changelog-starter) | 5.50.0 | 7.1.0 | Boot 4 line of the ror helpers |
| `springdoc-openapi-starter-webmvc-ui` | 2.8.16 | 3.0.3 | springdoc 3.x requires Boot 4 |

### Boot 4 relocations handled in code
- `ErrorController` → `org.springframework.boot.webmvc.error`
- `AutoConfigureMockMvc` → `org.springframework.boot.webmvc.test.autoconfigure`
- Added `spring-boot-webmvc-test` (test scope) — the MockMvc slice is no longer bundled in `spring-boot-starter-test`

### Intentionally not changed
- **netex-parser-java held at 3.1.78** — it's a plain (non-Spring) library and doesn't block Boot 4. Its v4 line (which pulls netex-java-model) is deliberately out of scope.

### Verification
`mvn clean verify` is green locally — all 100 tests pass, including the 40-test `RestResourceIntegrationTest` MockMvc suite validating against the regenerated OpenAPI spec.

### Supersedes / closes
This delivers the changes from Renovate PRs #335, #319 and #315; they can be closed once this merges. Also obsoletes #343 (springdoc 2.8.17).