### PR TITLE
Dependency sweep: safe-to-merge upgrades (jaxb, test validator, temurin patch, CI actions)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Check for breaking API changes
         if: github.event_name == 'pull_request'
-        uses: oasdiff/oasdiff-action/breaking@v0.1.1
+        uses: oasdiff/oasdiff-action/breaking@5fbe96ede8d0c53aeadef122d7a0abb79152d493 # v0.1.1
         with:
           base: 'origin/${{ github.base_ref }}:src/main/resources/public/openapi.json'
           revision: 'HEAD:src/main/resources/public/openapi.json'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Check for breaking API changes
         if: github.event_name == 'pull_request'
-        uses: oasdiff/oasdiff-action/breaking@v0.0.37
+        uses: oasdiff/oasdiff-action/breaking@v0.1.1
         with:
           base: 'origin/${{ github.base_ref }}:src/main/resources/public/openapi.json'
           revision: 'HEAD:src/main/resources/public/openapi.json'
@@ -64,11 +64,11 @@ jobs:
                   -Dsonar.projectName=${SONAR_PROJECT_NAME} \
                   -Dsonar.host.url=https://sonarcloud.io \
                   -Dsonar.token=${SONAR_TOKEN}
-      - uses: actions/upload-artifact@v4.6.2
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: target
           path: target
-      - uses: actions/upload-artifact@v4.6.2
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: apispec
           path: src/main/resources/public/openapi.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.10_7-jdk-alpine
+FROM eclipse-temurin:21.0.11_10-jdk-alpine
 
 RUN apk update && apk upgrade && apk add --no-cache \
     tini

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <entur.helpers.version>5.50.0</entur.helpers.version>
         <netex-parser-java.version>3.1.78</netex-parser-java.version>
         <jakarta-xml-bind.version>4.0.5</jakarta-xml-bind.version>
-        <glassfish-jaxb.version>4.0.7</glassfish-jaxb.version>
+        <glassfish-jaxb.version>4.0.9</glassfish-jaxb.version>
     </properties>
 
     <licenses>
@@ -118,8 +118,8 @@
         </dependency>
         <dependency>
             <groupId>com.atlassian.oai</groupId>
-            <artifactId>swagger-request-validator-mockmvc</artifactId>
-            <version>2.46.1</version>
+            <artifactId>openapi-request-validator-mockmvc</artifactId>
+            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Safe-to-merge dependency sweep

A batch of low-risk, CI-green upgrades, independent of the Spring Boot 4 work in #355. Each was already passing on `master` as its own Renovate PR; this bundles them into one reviewable PR.

| Change | From | To | PR |
|---|---|---|---|
| glassfish `jaxb-runtime` | 4.0.7 | 4.0.9 | #349 |
| test validator (artifact rename in v3) | `swagger-request-validator-mockmvc` 2.46.1 | `openapi-request-validator-mockmvc` 3.0.0 | supersedes #353, per #352 |
| Docker base image | `eclipse-temurin:21.0.10_7` | `21.0.11_10` (patch) | #350 |
| CI `actions/upload-artifact` | v4.6.2 | v7.0.1 | #307 |
| CI `oasdiff-action` | v0.0.37 | v0.1.1 | #341 |

### Notes
- **netex-parser-java deliberately untouched** (held at 3.1.78); nothing here pulls netex-java-model.
- The validator change is a major bump (v2→v3) where Atlassian renamed the artifact `swagger-*` → `openapi-*`; the Java package stays `com.atlassian.oai.validator.*`, so no test code changes were needed.
- `mvn clean verify` green locally — all 100 tests pass.

### Supersedes
Delivers Renovate PRs #349, #350, #307, #341, and the validator swap (#352, superseding #353).