### PR TITLE
Stop JSON serialization from mutating shared model and leaking empty elements into XML

### DIFF
--- a/src/main/java/no/entur/mummu/config/WebConfig.java
+++ b/src/main/java/no/entur/mummu/config/WebConfig.java
@@ -1,6 +1,8 @@
 package no.entur.mummu.config;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -72,6 +74,18 @@ public class WebConfig implements WebMvcConfigurer {
                 .serializationInclusion(JsonInclude.Include.NON_EMPTY)
                 .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .featuresToEnable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+                // Serialize via fields, not getters. The NeTEx model getters lazy-initialize
+                // collection fields (null -> empty list) on first call. Because the index holds
+                // shared entity instances, getter-based JSON serialization permanently mutates
+                // them; a later XML (JAXB) response then marshals those empty lists as empty
+                // elements (e.g. <CardsAccepted></CardsAccepted>), which is invalid NeTEx.
+                // Reading fields directly avoids triggering the getters and keeps the shared
+                // model immutable across requests. Explicitly annotated getters (the mixins)
+                // are still honoured regardless of visibility.
+                .visibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE)
+                .visibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE)
+                .visibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE)
+                .visibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
                 .modules(modules)
                 .mixIn(Quays_RelStructure.class, NetexJsonMixins.QuaysRelStructureMixin.class)
                 .mixIn(TariffZoneRefs_RelStructure.class, NetexJsonMixins.TariffZoneRefsRelStructureMixin.class)

--- a/src/test/java/no/entur/mummu/RestResourceIntegrationTest.java
+++ b/src/test/java/no/entur/mummu/RestResourceIntegrationTest.java
@@ -58,6 +58,9 @@ class RestResourceIntegrationTest {
     @Autowired
     private MockMvc mvc;
 
+    @Autowired
+    private no.entur.mummu.services.NetexEntitiesIndexLoader netexEntitiesIndexLoader;
+
     @Test
     void testGetGroupsOfStopPlaces() throws Exception {
 
@@ -439,6 +442,48 @@ class RestResourceIntegrationTest {
                         .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.name.value").value("Jernbanetorget"))
                 .andExpect(openApi().isValid(validator));
+    }
+
+    @Test
+    void testJsonSerializationDoesNotMutateSharedModel() throws Exception {
+        // The index holds a single shared Parking instance. The NeTEx model's collection
+        // getters lazy-initialise (null -> new ArrayList<>()). If Jackson serialized via
+        // those getters it would permanently mutate the shared object, and a later XML
+        // response would then marshal the empty lists as empty elements (invalid NeTEx).
+        // cardsAccepted is absent from the fixture, so the field must stay null across a
+        // JSON request - proving JSON serialization uses field access and does not mutate.
+        var parking = netexEntitiesIndexLoader.getNetexEntitiesIndex()
+                .getParkingIndex().getLatestVersion("NSR:Parking:1");
+        var field = org.rutebanken.netex.model.Parking_VersionStructure.class
+                .getDeclaredField("cardsAccepted");
+        field.setAccessible(true);
+        Assertions.assertNull(field.get(parking), "precondition: cardsAccepted starts null");
+
+        mvc.perform(get("/parkings/NSR:Parking:1").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        Assertions.assertNull(field.get(parking),
+                "JSON serialization must not lazy-init cardsAccepted on the shared model");
+    }
+
+    @Test
+    void testJsonRequestDoesNotLeakFabricatedEmptyElementsIntoXml() throws Exception {
+        // A JSON request followed by an XML request for the same shared entity must not
+        // introduce empty elements that were never in the source data.
+        mvc.perform(get("/parkings/NSR:Parking:1").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        String xml = mvc.perform(get("/parkings/NSR:Parking:1")
+                        .accept(MediaType.APPLICATION_XML))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        // These were never in the source; they must not be fabricated into the XML.
+        Assertions.assertFalse(xml.contains("<CardsAccepted"), xml);
+        Assertions.assertFalse(xml.contains("<PaymentMethods"), xml);
+        Assertions.assertFalse(xml.contains("<CurrenciesAccepted"), xml);
+        // Real content is still present.
+        Assertions.assertTrue(xml.contains("<ParkingVehicleTypes>pedalCycle</ParkingVehicleTypes>"), xml);
     }
 
     @Test


### PR DESCRIPTION
## Problem

API consumers reported invalid NeTEx from the read-API, e.g. `GET /parkings/NSR:Parking:11` returning:

```xml
<CardsAccepted></CardsAccepted>
```

which fails schema validation (`cvc-minLength-valid: ... NMTOKENS`). The same parkings exported directly from tiamat (both the bulk `Full_latest.zip` and tiamat's live `/services/stop_places/netex` endpoint) do **not** contain these elements — so the read-API was fabricating them.

## Root cause — a cross-content-type state leak

`NetexEntitiesIndex` holds a **single shared, mutable** instance per entity. The JSON mapper serialized via **getters** under `JsonInclude.NON_EMPTY`, and the NeTEx model's collection getters **lazy-initialize**:

```java
public List<String> getCardsAccepted() {
    if (cardsAccepted == null) cardsAccepted = new ArrayList<>();
    return cardsAccepted;
}
```

So merely serializing a JSON response (Jackson calls every getter to evaluate `NON_EMPTY`) permanently mutated the shared entity, flipping `null` collection fields to empty lists. A **later XML request** — possibly from a different client — then marshalled those empty lists as empty elements via JAXB. Cause and symptom were decoupled in time, request, and content type, which is why it initially looked like stale data or an upstream tiamat bug.

This was verified end-to-end: tiamat's live export is clean, a freshly parsed `Parking` has `null` fields, and a single JSON serialization flips them to empty lists.

## Fix

Configure the Jackson mapper (`WebConfig.jsonObjectMapper()`) to serialize via **field access** instead of getters, so JSON serialization never triggers the lazy-init getters and the shared model stays immutable across requests. Mixin getters (explicitly annotated) are still honoured.

## Consequences

- **XML**: no longer fabricates `CardsAccepted` / `CurrenciesAccepted` / `PaymentMethods` / `AccessModes` / etc. — resolving the reported validation error.
- **JSON**: no longer emits four synthesized default-valued metadata attributes (`modification`, `publication`, `status_BasicModificationDetailsGroup`, `modificationSet`) when absent from the source. This makes JSON **consistent with the XML output and the source NeTEx** (JAXB already uses field access). Heads-up worth noting for API consumers.
- **Residual**: tiamat genuinely emits a couple of empty elements (`<ParkingPaymentProcess>`, `<ParkingUserTypes>`) which still pass through; they are not `NMTOKENS`-constrained and do not fail validation. Eliminating those is a separate upstream tiamat change.

## Tests

- `testJsonSerializationDoesNotMutateSharedModel` — a JSON request leaves the shared model's `cardsAccepted` field `null`.
- `testJsonRequestDoesNotLeakFabricatedEmptyElementsIntoXml` — JSON-then-XML for the same entity does not introduce empty elements absent from the source.

All 102 tests pass.