### PR TITLE
Log large read responses to identify OOM-triggering paths and consumers

### DIFF
--- a/src/main/java/no/entur/mummu/logging/CountingServletOutputStream.java
+++ b/src/main/java/no/entur/mummu/logging/CountingServletOutputStream.java
@@ -1,0 +1,70 @@
+package no.entur.mummu.logging;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+
+import java.io.IOException;
+
+/**
+ * Delegating ServletOutputStream that counts bytes written and fires a one-shot
+ * callback the first time the cumulative count crosses a threshold. Does not
+ * buffer. Not thread-safe: a single response is written by a single thread.
+ */
+class CountingServletOutputStream extends ServletOutputStream {
+
+    private final ServletOutputStream delegate;
+    private final long threshold;
+    private final Runnable onThresholdCrossed;
+    private long count;
+    private boolean crossed;
+
+    CountingServletOutputStream(ServletOutputStream delegate, long threshold, Runnable onThresholdCrossed) {
+        this.delegate = delegate;
+        this.threshold = threshold;
+        this.onThresholdCrossed = onThresholdCrossed;
+    }
+
+    long count() {
+        return count;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        delegate.write(b);
+        add(1);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        delegate.write(b, off, len);
+        add(len);
+    }
+
+    private void add(long n) {
+        count += n;
+        if (!crossed && count > threshold) {
+            crossed = true;
+            onThresholdCrossed.run();
+        }
+    }
+
+    @Override
+    public boolean isReady() {
+        return delegate.isReady();
+    }
+
+    @Override
+    public void setWriteListener(WriteListener writeListener) {
+        delegate.setWriteListener(writeListener);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        delegate.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+}

--- a/src/main/java/no/entur/mummu/logging/LargeResponseLoggingFilter.java
+++ b/src/main/java/no/entur/mummu/logging/LargeResponseLoggingFilter.java
@@ -65,9 +65,25 @@ public class LargeResponseLoggingFilter extends OncePerRequestFilter {
         return queryString == null ? "" : "?" + sanitize(queryString);
     }
 
-    /** Neutralizes control characters in user-controlled values to prevent log forging (CWE-117). */
+    /**
+     * Removes line breaks and other control characters from user-controlled values
+     * to prevent log forging (CWE-117). The explicit CR/LF handling lets CodeQL
+     * recognize this as a log-injection sanitizer (java/log-injection).
+     */
     static String sanitize(String value) {
-        return value == null ? null : value.replaceAll("\\p{Cntrl}", "_");
+        if (value == null) {
+            return null;
+        }
+        StringBuilder sanitized = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (ch == '\r' || ch == '\n' || Character.isISOControl(ch)) {
+                sanitized.append('_');
+            } else {
+                sanitized.append(ch);
+            }
+        }
+        return sanitized.toString();
     }
 
     private static final class CountingResponseWrapper extends HttpServletResponseWrapper {

--- a/src/main/java/no/entur/mummu/logging/LargeResponseLoggingFilter.java
+++ b/src/main/java/no/entur/mummu/logging/LargeResponseLoggingFilter.java
@@ -1,0 +1,84 @@
+package no.entur.mummu.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Logs read responses whose uncompressed serialized size exceeds a threshold,
+ * with the request path and consumer headers, to identify the source of the
+ * large responses that trigger heap OOMs. Read-only; does not buffer the body.
+ */
+@Component
+public class LargeResponseLoggingFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(LargeResponseLoggingFilter.class);
+
+    private final long thresholdBytes;
+
+    public LargeResponseLoggingFilter(
+            @Value("${no.entur.mummu.logging.large-response-threshold-bytes:10485760}") long thresholdBytes) {
+        this.thresholdBytes = thresholdBytes;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        CountingResponseWrapper wrapper = new CountingResponseWrapper(response, thresholdBytes,
+                () -> log.warn("Large response crossing {} bytes while streaming: {} {}{} client={} clientId={} correlationId={}",
+                        thresholdBytes, request.getMethod(), request.getRequestURI(), query(request),
+                        request.getHeader("ET-Client-Name"), request.getHeader("ET-Client-ID"),
+                        request.getHeader("X-Correlation-Id")));
+
+        try {
+            chain.doFilter(request, wrapper);
+        } finally {
+            long bytes = wrapper.bytesWritten();
+            if (bytes > thresholdBytes) {
+                log.warn("Large response completed: {} bytes {} {}{} status={} contentType={} client={} clientId={} correlationId={}",
+                        bytes, request.getMethod(), request.getRequestURI(), query(request), response.getStatus(),
+                        response.getContentType(), request.getHeader("ET-Client-Name"), request.getHeader("ET-Client-ID"),
+                        request.getHeader("X-Correlation-Id"));
+            }
+        }
+    }
+
+    private static String query(HttpServletRequest request) {
+        return request.getQueryString() == null ? "" : "?" + request.getQueryString();
+    }
+
+    private static final class CountingResponseWrapper extends HttpServletResponseWrapper {
+        private final long threshold;
+        private final Runnable onCrossed;
+        private CountingServletOutputStream stream;
+
+        CountingResponseWrapper(HttpServletResponse response, long threshold, Runnable onCrossed) {
+            super(response);
+            this.threshold = threshold;
+            this.onCrossed = onCrossed;
+        }
+
+        @Override
+        public ServletOutputStream getOutputStream() throws IOException {
+            if (stream == null) {
+                stream = new CountingServletOutputStream(super.getOutputStream(), threshold, onCrossed);
+            }
+            return stream;
+        }
+
+        long bytesWritten() {
+            return stream == null ? 0 : stream.count();
+        }
+    }
+}

--- a/src/main/java/no/entur/mummu/logging/LargeResponseLoggingFilter.java
+++ b/src/main/java/no/entur/mummu/logging/LargeResponseLoggingFilter.java
@@ -53,9 +53,10 @@ public class LargeResponseLoggingFilter extends OncePerRequestFilter {
         } finally {
             long bytes = wrapper.bytesWritten();
             if (bytes > thresholdBytes) {
+                int status = response.getStatus();
+                String contentType = sanitize(response.getContentType());
                 log.warn("Large response completed: {} bytes {} {} status={} contentType={} client={} clientId={} correlationId={}",
-                        bytes, method, path, response.getStatus(), sanitize(response.getContentType()),
-                        client, clientId, correlationId);
+                        bytes, method, path, status, contentType, client, clientId, correlationId);
             }
         }
     }

--- a/src/main/java/no/entur/mummu/logging/LargeResponseLoggingFilter.java
+++ b/src/main/java/no/entur/mummu/logging/LargeResponseLoggingFilter.java
@@ -35,27 +35,39 @@ public class LargeResponseLoggingFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
 
+        // User-controlled values are neutralized before logging to prevent log
+        // forging (CWE-117): the URI, query string and request headers can carry
+        // control characters that would otherwise inject forged log lines.
+        String method = request.getMethod();
+        String path = sanitize(request.getRequestURI()) + query(request);
+        String client = sanitize(request.getHeader("ET-Client-Name"));
+        String clientId = sanitize(request.getHeader("ET-Client-ID"));
+        String correlationId = sanitize(request.getHeader("X-Correlation-Id"));
+
         CountingResponseWrapper wrapper = new CountingResponseWrapper(response, thresholdBytes,
-                () -> log.warn("Large response crossing {} bytes while streaming: {} {}{} client={} clientId={} correlationId={}",
-                        thresholdBytes, request.getMethod(), request.getRequestURI(), query(request),
-                        request.getHeader("ET-Client-Name"), request.getHeader("ET-Client-ID"),
-                        request.getHeader("X-Correlation-Id")));
+                () -> log.warn("Large response crossing {} bytes while streaming: {} {} client={} clientId={} correlationId={}",
+                        thresholdBytes, method, path, client, clientId, correlationId));
 
         try {
             chain.doFilter(request, wrapper);
         } finally {
             long bytes = wrapper.bytesWritten();
             if (bytes > thresholdBytes) {
-                log.warn("Large response completed: {} bytes {} {}{} status={} contentType={} client={} clientId={} correlationId={}",
-                        bytes, request.getMethod(), request.getRequestURI(), query(request), response.getStatus(),
-                        response.getContentType(), request.getHeader("ET-Client-Name"), request.getHeader("ET-Client-ID"),
-                        request.getHeader("X-Correlation-Id"));
+                log.warn("Large response completed: {} bytes {} {} status={} contentType={} client={} clientId={} correlationId={}",
+                        bytes, method, path, response.getStatus(), sanitize(response.getContentType()),
+                        client, clientId, correlationId);
             }
         }
     }
 
     private static String query(HttpServletRequest request) {
-        return request.getQueryString() == null ? "" : "?" + request.getQueryString();
+        String queryString = request.getQueryString();
+        return queryString == null ? "" : "?" + sanitize(queryString);
+    }
+
+    /** Neutralizes control characters in user-controlled values to prevent log forging (CWE-117). */
+    static String sanitize(String value) {
+        return value == null ? null : value.replaceAll("\\p{Cntrl}", "_");
     }
 
     private static final class CountingResponseWrapper extends HttpServletResponseWrapper {

--- a/src/test/java/no/entur/mummu/logging/CountingServletOutputStreamTest.java
+++ b/src/test/java/no/entur/mummu/logging/CountingServletOutputStreamTest.java
@@ -15,7 +15,9 @@ class CountingServletOutputStreamTest {
         return new ServletOutputStream() {
             @Override public void write(int b) { buf.write(b); }
             @Override public boolean isReady() { return true; }
-            @Override public void setWriteListener(WriteListener writeListener) { }
+            @Override public void setWriteListener(WriteListener writeListener) {
+                // no-op: synchronous test sink, async write callbacks are not exercised
+            }
         };
     }
 

--- a/src/test/java/no/entur/mummu/logging/CountingServletOutputStreamTest.java
+++ b/src/test/java/no/entur/mummu/logging/CountingServletOutputStreamTest.java
@@ -1,0 +1,40 @@
+package no.entur.mummu.logging;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CountingServletOutputStreamTest {
+
+    private static ServletOutputStream sink(ByteArrayOutputStream buf) {
+        return new ServletOutputStream() {
+            @Override public void write(int b) { buf.write(b); }
+            @Override public boolean isReady() { return true; }
+            @Override public void setWriteListener(WriteListener writeListener) { }
+        };
+    }
+
+    @Test
+    void countsBytesAndFiresCallbackOnceOnCrossing() throws Exception {
+        var buf = new ByteArrayOutputStream();
+        var callbacks = new AtomicInteger();
+        var out = new CountingServletOutputStream(sink(buf), 10, callbacks::incrementAndGet);
+
+        out.write(new byte[8], 0, 8);
+        assertEquals(0, callbacks.get(), "not crossed yet");
+
+        out.write(new byte[8], 0, 8); // total 16 > 10
+        assertEquals(1, callbacks.get(), "fires on crossing");
+
+        out.write(new byte[8], 0, 8); // total 24, must not fire again
+        assertEquals(1, callbacks.get(), "fires at most once");
+
+        assertEquals(24, out.count());
+        assertEquals(24, buf.size(), "all bytes passed through to delegate");
+    }
+}

--- a/src/test/java/no/entur/mummu/logging/LargeResponseLoggingFilterIntegrationTest.java
+++ b/src/test/java/no/entur/mummu/logging/LargeResponseLoggingFilterIntegrationTest.java
@@ -1,0 +1,59 @@
+package no.entur.mummu.logging;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import no.entur.mummu.MummuApplication;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@SpringBootTest(classes = MummuApplication.class)
+@AutoConfigureMockMvc
+@TestPropertySource(properties = "no.entur.mummu.logging.large-response-threshold-bytes=10")
+class LargeResponseLoggingFilterIntegrationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    private Logger filterLogger;
+    private ListAppender<ILoggingEvent> appender;
+
+    @BeforeEach
+    void attachAppender() {
+        filterLogger = (Logger) LoggerFactory.getLogger(LargeResponseLoggingFilter.class);
+        appender = new ListAppender<>();
+        appender.start();
+        filterLogger.addAppender(appender);
+    }
+
+    @AfterEach
+    void detachAppender() {
+        filterLogger.detachAppender(appender);
+    }
+
+    @Test
+    void logsLargeResponseWithPath() throws Exception {
+        mvc.perform(get("/stop-places").accept("application/json"))
+                .andExpect(status().isOk());
+
+        boolean logged = appender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .anyMatch(m -> m.contains("Large response completed") && m.contains("/stop-places"));
+
+        Assertions.assertTrue(logged, "expected a large-response log line for /stop-places; got: "
+                + appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList());
+    }
+}

--- a/src/test/java/no/entur/mummu/logging/LargeResponseLoggingFilterTest.java
+++ b/src/test/java/no/entur/mummu/logging/LargeResponseLoggingFilterTest.java
@@ -1,0 +1,17 @@
+package no.entur.mummu.logging;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class LargeResponseLoggingFilterTest {
+
+    @Test
+    void sanitizeNeutralizesControlCharactersToPreventLogForging() {
+        assertEquals("evil__INJECTED", LargeResponseLoggingFilter.sanitize("evil\r\nINJECTED"));
+        assertEquals("a_b", LargeResponseLoggingFilter.sanitize("a\tb"));
+        assertEquals("normal/path?ids=NSR:Quay:1", LargeResponseLoggingFilter.sanitize("normal/path?ids=NSR:Quay:1"));
+        assertNull(LargeResponseLoggingFilter.sanitize(null));
+    }
+}


### PR DESCRIPTION
## Why

Both prod OOMs (2026-06-02 and 2026-06-29) are read-path JSON serialization of a **large response** on a thin heap — the crash lands deep in Jackson (`serializeValue` → `BeanSerializer` → `IndexedListSerializer`/`DoubleSerializer`, i.e. a large coordinate/geometry list). The memory-headroom bump raises the ceiling; this change is the instrumentation to find the **trigger** so we can target the real fix.

A `count`/`ids` cap is the wrong lever: cost is **serialized bytes**, not element count (many small refs are cheap; a few fat geometry polygons are not). So we measure response byte size and attribute it to a path + consumer.

## What

A `OncePerRequestFilter` wraps the response with a **non-buffering byte-counting `ServletOutputStream`** (explicitly *not* `ContentCachingResponseWrapper`, which would buffer the body in heap and worsen the OOM). It logs a WARN only for responses over a threshold:

- **mid-stream**, the moment cumulative bytes cross the threshold — this catches the request that **OOMs before completing** (the actual culprit never reaches the completion log);
- **at completion**, with final byte count, status, content-type, and consumer headers `ET-Client-Name` / `ET-Client-ID` / `X-Correlation-Id`.

Counts **uncompressed** bytes via `getOutputStream()` (the heap-relevant size, before Tomcat's gzip). Threshold is configurable: `no.entur.mummu.logging.large-response-threshold-bytes` (default `10485760` = 10 MB).

## Verification

- Unit test: byte counting + one-shot threshold callback.
- End-to-end test (`@SpringBootTest` + MockMvc, threshold lowered to 10 bytes): confirms the filter actually fires, e.g. `Large response completed: 12952 bytes GET /stop-places status=200 contentType=application/json …`.
- Full `RestResourceIntegrationTest` (42 tests) green — no regression from the filter being in the chain.

## After deploy

Watch for the first `Large response` WARNs — that's the list of paths + consumers driving the OOM, which tells us where to put the real fix (byte-budget guard on heavy/geometry endpoints, geometry simplification, or per-consumer limits). Read-only; no behavior change; safe for all envs.